### PR TITLE
Add support for once-nested comment blocks.

### DIFF
--- a/StataEditor.tmLanguage
+++ b/StataEditor.tmLanguage
@@ -24,6 +24,7 @@
 			<string>\*/</string>
 			<key>name</key>
 			<string>comment.block.stata</string>
+			<key>patterns</key>
 			<array>
 				<dict>
 					<key>begin</key>

--- a/StataEditor.tmLanguage
+++ b/StataEditor.tmLanguage
@@ -24,6 +24,16 @@
 			<string>\*/</string>
 			<key>name</key>
 			<string>comment.block.stata</string>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>/\*</string>
+					<key>end</key>
+					<string>\*/</string>
+					<key>name</key>
+					<string>comment.block.stata</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
Fixes: https://github.com/mattiasnordin/StataEditor/issues/6
Explanation is in that issue thread. 