### PR TITLE
Update StataEditor.tmLanguage

### DIFF
--- a/StataEditor.tmLanguage
+++ b/StataEditor.tmLanguage
@@ -12,8 +12,10 @@
 	<key>patterns</key>
 	<array>
 		<dict>
-			<key>match</key>
+			<key>begin</key>
 			<string>^\s*//.*|\s+//.*|^\s*\*.*</string>
+			<key>end</key>
+			<string>\n</string>
 			<key>name</key>
 			<string>comment.line.stata</string>
 		</dict>


### PR DESCRIPTION
Make StataEditor immediately switch to comment.line scope once // (anywhere) or * (at line start) is inserted. This prevents auto-completion in line comments, similar to how stock R or C syntaxes behave.